### PR TITLE
Adds Authentication to Gateway facing APIs

### DIFF
--- a/abdm_integrator/const.py
+++ b/abdm_integrator/const.py
@@ -2,10 +2,14 @@ import celery
 
 from abdm_integrator.settings import app_settings
 
-SESSIONS_PATH = '/v0.5/sessions'
 GATEWAY_CALLBACK_URL_PREFIX = 'api/gateway/v0.5'
 
 CELERY_TASK = app_settings.CELERY_APP.task if app_settings.CELERY_APP else celery.shared_task
+
+
+class GatewayAPIPath:
+    SESSIONS_PATH = '/v0.5/sessions'
+    CERTS_PATH = '/v0.5/certs'
 
 
 class ConsentStatus:

--- a/abdm_integrator/hip/views/base.py
+++ b/abdm_integrator/hip/views/base.py
@@ -3,6 +3,7 @@ from rest_framework.views import APIView
 
 from abdm_integrator.hip.exceptions import hip_error_response_handler, hip_gateway_error_response_handler
 from abdm_integrator.settings import app_settings
+from abdm_integrator.utils import ABDMGatewayAuthentication
 
 
 class HIPBaseView(APIView):
@@ -14,6 +15,7 @@ class HIPBaseView(APIView):
 
 
 class HIPGatewayBaseView(APIView):
+    authentication_classes = [ABDMGatewayAuthentication]
 
     def get_exception_handler(self):
         return hip_gateway_error_response_handler.get_exception_handler()

--- a/abdm_integrator/hiu/views/base.py
+++ b/abdm_integrator/hiu/views/base.py
@@ -3,6 +3,7 @@ from rest_framework.views import APIView
 
 from abdm_integrator.hiu.exceptions import hiu_error_response_handler, hiu_gateway_error_response_handler
 from abdm_integrator.settings import app_settings
+from abdm_integrator.utils import ABDMGatewayAuthentication
 
 
 class HIUBaseView(APIView):
@@ -14,6 +15,7 @@ class HIUBaseView(APIView):
 
 
 class HIUGatewayBaseView(APIView):
+    authentication_classes = [ABDMGatewayAuthentication]
 
     def get_exception_handler(self):
         return hiu_gateway_error_response_handler.get_exception_handler()

--- a/abdm_integrator/user_auth/views.py
+++ b/abdm_integrator/user_auth/views.py
@@ -19,7 +19,12 @@ from abdm_integrator.user_auth.serializers import (
     GatewayAuthOnFetchModesSerializer,
     GatewayAuthOnInitSerializer,
 )
-from abdm_integrator.utils import ABDMCache, ABDMRequestHelper, poll_and_pop_data_from_cache
+from abdm_integrator.utils import (
+    ABDMCache,
+    ABDMGatewayAuthentication,
+    ABDMRequestHelper,
+    poll_and_pop_data_from_cache,
+)
 
 
 class UserAuthBaseView(APIView):
@@ -40,6 +45,7 @@ class UserAuthBaseView(APIView):
 
 
 class UserAuthGatewayBaseView(APIView):
+    authentication_classes = [ABDMGatewayAuthentication]
     serializer_class = None
 
     def get_exception_handler(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "djangorestframework >= 3.12",
     "requests",
     "drf-standardized-errors",
-    "celery"
+    "celery",
+    "pyjwt[crypto]"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
ABDM Gateway sends a JWT token to all the Gateway facing APIs served by this application, The mechanism for authentication uses JWK (JSON web keys) which is well explained [here](https://www.unosquare.com/blog/why-and-how-to-improve-jwt-security-with-jwks-key-rotation-in-java/).

Uses the library [PyJwt](https://pyjwt.readthedocs.io/en/stable/) (already used in HQ ) for the validation of access token,

The JSON web keys are available [here](https://dev.ndhm.gov.in/gateway/v0.5/certs) and is stored in cache for 180 mins post that fresh keys are obtained. 