### PR TITLE
API for care context link notify

### DIFF
--- a/abdm_integrator/hip/const.py
+++ b/abdm_integrator/hip/const.py
@@ -2,6 +2,7 @@
 class HIPGatewayAPIPath:
     CONSENT_REQUEST_ON_NOTIFY_PATH = '/v0.5/consents/hip/on-notify'
     ADD_CARE_CONTEXTS = '/v0.5/links/link/add-contexts'
+    CARE_CONTEXTS_LINK_NOTIFY = '/v0.5/links/context/notify'
     HEALTH_INFO_ON_REQUEST = '/v0.5/health-information/hip/on-request'
     HEALTH_INFO_NOTIFY = '/v0.5/health-information/notify'
     HEALTH_INFO_ON_TRANSFER = '/v0.5/health-information/notify'

--- a/abdm_integrator/hip/serializers/care_contexts.py
+++ b/abdm_integrator/hip/serializers/care_contexts.py
@@ -29,6 +29,7 @@ class LinkCareContextRequestSerializer(serializers.Serializer):
     accessToken = serializers.CharField()
     hip_id = serializers.CharField()
     patient = PatientSerializer()
+    healthId = serializers.CharField()
 
 
 class GatewayOnAddContextsSerializer(GatewayCallbackResponseBaseSerializer):

--- a/abdm_integrator/hip/tasks.py
+++ b/abdm_integrator/hip/tasks.py
@@ -39,6 +39,12 @@ def process_patient_care_context_link_confirm_request(self, request_data):
     GatewayCareContextsLinkConfirmProcessor(request_data).process_request()
 
 
+@CELERY_TASK(queue=app_settings.CELERY_QUEUE, bind=True, ignore_result=False)
+def process_care_context_link_notify(self, link_request_data):
+    from abdm_integrator.hip.views.care_contexts import gateway_care_contexts_link_notify
+    gateway_care_contexts_link_notify(link_request_data)
+
+
 @CELERY_PERIODIC_TASK(run_every=crontab(hour='*/2', minute='0'), queue=app_settings.CELERY_QUEUE)
 def process_hip_expired_consents():
     _process_hip_expired_consents()

--- a/abdm_integrator/hip/tests/test_care_contexts.py
+++ b/abdm_integrator/hip/tests/test_care_contexts.py
@@ -68,6 +68,7 @@ class TestHIPLinkCareContextAPI(APITestCase, APITestHelperMixin):
         return {
             'accessToken': 'abcdefghi',
             'hip_id': '1001',
+            'healthId': 'test@sbx',
             'patient': {
                 'referenceNumber': 'Test_001',
                 'display': 'Test User',
@@ -123,6 +124,7 @@ class TestHIPLinkCareContextAPI(APITestCase, APITestHelperMixin):
         self.assertEqual(LinkCareContext.objects.all().count(), count)
         self.assertEqual(HIPLinkRequest.objects.all().count(), count)
 
+    @patch('abdm_integrator.hip.views.care_contexts.process_care_context_link_notify')
     @patch('abdm_integrator.hip.views.care_contexts.ABDMRequestHelper.gateway_post', return_value={})
     @patch('abdm_integrator.hip.views.care_contexts.ABDMRequestHelper.common_request_data')
     def test_link_care_context_success(self, mocked_common_request_data, *args):

--- a/abdm_integrator/hip/urls.py
+++ b/abdm_integrator/hip/urls.py
@@ -5,6 +5,7 @@ from abdm_integrator.hip.views.care_contexts import (
     GatewayCareContextsDiscover,
     GatewayCareContextsLinkConfirm,
     GatewayCareContextsLinkInit,
+    GatewayCareContextsLinkOnNotify,
     GatewayOnAddContexts,
     GatewayPatientSMSOnNotify,
     LinkCareContextRequest,
@@ -31,4 +32,6 @@ hip_urls = [
          name='gateway_care_contexts_link_confirm'),
     path(f'{GATEWAY_CALLBACK_URL_PREFIX}/patients/sms/on-notify', GatewayPatientSMSOnNotify.as_view(),
          name='gateway_patient_sms_on_notify'),
+    path(f'{GATEWAY_CALLBACK_URL_PREFIX}/links/context/on-notify', GatewayCareContextsLinkOnNotify.as_view(),
+         name='gateway_care_contexts_link_on_notify'),
 ]


### PR DESCRIPTION
ABDM requested for adding this API that would be called once Care Context is succesfully linked.
This API is called asynchronously.