### PR TITLE
Updates date time format to use millseconds instead of microseconds for abdm calls

### DIFF
--- a/abdm_integrator/crypto.py
+++ b/abdm_integrator/crypto.py
@@ -4,6 +4,8 @@ from datetime import datetime, timedelta
 
 from fidelius import CryptoController, DecryptionRequest, EncryptionRequest, KeyMaterial
 
+from abdm_integrator.utils import datetime_to_abdm_iso
+
 CRYPTO_ALGORITHM = 'ECDH'
 CURVE = 'Curve25519'
 KEY_MATERIAL_EXPIRY = 60 * 60  # in seconds
@@ -36,7 +38,7 @@ class ABDMCrypto:
             'cryptoAlg': CRYPTO_ALGORITHM,
             'curve': CURVE,
             'dhPublicKey': {
-                'expiry': (datetime.utcnow() + timedelta(seconds=KEY_MATERIAL_EXPIRY)).isoformat(),
+                'expiry': datetime_to_abdm_iso(datetime.utcnow() + timedelta(seconds=KEY_MATERIAL_EXPIRY)),
                 'parameters': CURVE,
                 'keyValue': (self.key_material.x509_public_key if use_x509_for_transfer
                              else self.key_material.public_key)

--- a/abdm_integrator/hip/const.py
+++ b/abdm_integrator/hip/const.py
@@ -5,7 +5,6 @@ class HIPGatewayAPIPath:
     CARE_CONTEXTS_LINK_NOTIFY = '/v0.5/links/context/notify'
     HEALTH_INFO_ON_REQUEST = '/v0.5/health-information/hip/on-request'
     HEALTH_INFO_NOTIFY = '/v0.5/health-information/notify'
-    HEALTH_INFO_ON_TRANSFER = '/v0.5/health-information/notify'
     CARE_CONTEXTS_ON_DISCOVER = '/v0.5/care-contexts/on-discover'
     CARE_CONTEXTS_LINK_ON_INIT = '/v0.5/links/link/on-init'
     CARE_CONTEXTS_LINK_ON_CONFIRM = '/v0.5/links/link/on-confirm'

--- a/abdm_integrator/hip/serializers/care_contexts.py
+++ b/abdm_integrator/hip/serializers/care_contexts.py
@@ -3,7 +3,11 @@ from rest_framework import serializers
 from abdm_integrator.const import Gender, HealthInformationType, IdentifierType
 from abdm_integrator.hip.const import SMSOnNotifyStatus
 from abdm_integrator.hip.models import LinkCareContext
-from abdm_integrator.serializers import GatewayCallbackResponseBaseSerializer, GatewayIdSerializer
+from abdm_integrator.serializers import (
+    ABDMDateTimeField,
+    GatewayCallbackResponseBaseSerializer,
+    GatewayIdSerializer,
+)
 from abdm_integrator.utils import past_date_validator
 
 
@@ -15,7 +19,7 @@ class LinkCareContextRequestSerializer(serializers.Serializer):
             class AdditionalInfoSerializer(serializers.Serializer):
                 # represents project to which record belongs to. Send dummy value if not applicable.
                 domain = serializers.CharField()
-                record_date = serializers.DateTimeField(validators=[past_date_validator])
+                record_date = ABDMDateTimeField(validators=[past_date_validator])
 
             referenceNumber = serializers.CharField()
             display = serializers.CharField()

--- a/abdm_integrator/hip/serializers/consents.py
+++ b/abdm_integrator/hip/serializers/consents.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from abdm_integrator.const import ConsentStatus, HealthInformationType
 from abdm_integrator.serializers import (
+    ABDMDateTimeField,
     GatewayCareContextSerializer,
     GatewayIdSerializer,
     GatewayPermissionSerializer,
@@ -16,7 +17,7 @@ class GatewayConsentRequestNotifySerializer(serializers.Serializer):
         class ConsentDetailSerializer(serializers.Serializer):
             schemaVersion = serializers.CharField(required=False)
             consentId = serializers.UUIDField()
-            createdAt = serializers.DateTimeField()
+            createdAt = ABDMDateTimeField()
             patient = GatewayIdSerializer()
             careContexts = serializers.ListField(child=GatewayCareContextSerializer(), min_length=1)
             purpose = GatewayPurposeSerializer()

--- a/abdm_integrator/hip/tests/test_care_contexts.py
+++ b/abdm_integrator/hip/tests/test_care_contexts.py
@@ -81,7 +81,7 @@ class TestHIPLinkCareContextAPI(APITestCase, APITestHelperMixin):
                         ],
                         'additionalInfo': {
                             'domain': 'test',
-                            'record_date': datetime.utcnow().isoformat()
+                            'record_date': f"{datetime.utcnow().isoformat(timespec='milliseconds')}Z"
                         }
                     }
                 ]

--- a/abdm_integrator/hip/views/care_contexts.py
+++ b/abdm_integrator/hip/views/care_contexts.py
@@ -56,6 +56,8 @@ from abdm_integrator.user_auth.views import AuthConfirm, AuthInit
 from abdm_integrator.utils import (
     ABDMCache,
     ABDMRequestHelper,
+    abdm_iso_to_datetime,
+    datetime_to_abdm_iso,
     poll_and_pop_data_from_cache,
     removes_prefix_for_abdm_mobile,
 )
@@ -458,13 +460,14 @@ class GatewayCareContextsLinkInitProcessor:
 
     @staticmethod
     def _generate_link_payload_from_otp_response(otp_response, link_reference):
+        expiry = datetime_to_abdm_iso(abdm_iso_to_datetime(otp_response['auth']['meta']['expiry']))
         return {
             'referenceNumber': str(link_reference),
             'authenticationType': AuthenticationMode.MOBILE_OTP,
             'meta': {
                 'communicationMedium': 'MOBILE',
                 'communicationHint': otp_response['auth']['meta']['hint'],
-                'communicationExpiry': otp_response['auth']['meta']['expiry']
+                'communicationExpiry': expiry,
             }
         }
 

--- a/abdm_integrator/hip/views/health_information.py
+++ b/abdm_integrator/hip/views/health_information.py
@@ -27,7 +27,7 @@ from abdm_integrator.hip.serializers.health_information import GatewayHealthInfo
 from abdm_integrator.hip.tasks import process_hip_health_information_request
 from abdm_integrator.hip.views.base import HIPGatewayBaseView
 from abdm_integrator.settings import app_settings
-from abdm_integrator.utils import ABDMRequestHelper, abdm_iso_to_datetime
+from abdm_integrator.utils import ABDMRequestHelper, abdm_iso_to_datetime, datetime_to_abdm_iso
 
 
 class GatewayHealthInformationRequest(HIPGatewayBaseView):
@@ -138,7 +138,7 @@ class GatewayHealthInformationRequestProcessor:
         payload['notification'] = {
             'consent_id': str(artefact.artefact_id),
             'transaction_id': self.request_data['transactionId'],
-            'doneAt': datetime.utcnow().isoformat(),
+            'doneAt': datetime_to_abdm_iso(datetime.utcnow()),
             'notifier': {
                 'type': RequesterType.HIP,
                 'id': artefact.details['hip']['id']

--- a/abdm_integrator/hiu/serializers/consents.py
+++ b/abdm_integrator/hiu/serializers/consents.py
@@ -8,6 +8,7 @@ from abdm_integrator.serializers import (
     ABDMDateTimeField,
     GatewayCallbackResponseBaseSerializer,
     GatewayCareContextSerializer,
+    GatewayIdNameSerializer,
     GatewayIdSerializer,
     GatewayPermissionSerializer,
     GatewayPurposeSerializer,
@@ -91,8 +92,8 @@ class GatewayConsentRequestOnFetchSerializer(GatewayCallbackResponseBaseSerializ
             patient = GatewayIdSerializer()
             careContexts = serializers.ListField(child=GatewayCareContextSerializer(), min_length=1)
             purpose = GatewayPurposeSerializer()
-            hip = GatewayIdSerializer()
-            hiu = GatewayIdSerializer()
+            hip = GatewayIdNameSerializer()
+            hiu = GatewayIdNameSerializer()
             consentManager = GatewayIdSerializer()
             requester = GatewayRequesterSerializer()
             hiTypes = serializers.ListField(child=serializers.ChoiceField(choices=HealthInformationType.CHOICES),

--- a/abdm_integrator/hiu/serializers/consents.py
+++ b/abdm_integrator/hiu/serializers/consents.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from abdm_integrator.const import ConsentPurpose, ConsentStatus, HealthInformationType
 from abdm_integrator.hiu.models import ConsentArtefact, ConsentRequest
 from abdm_integrator.serializers import (
+    ABDMDateTimeField,
     GatewayCallbackResponseBaseSerializer,
     GatewayCareContextSerializer,
     GatewayIdSerializer,
@@ -27,11 +28,11 @@ class GenerateConsentSerializer(serializers.Serializer):
 
     class PermissionSerializer(GatewayPermissionSerializer):
         class DateRangeSerializer(serializers.Serializer):
-            vars()['from'] = serializers.DateTimeField(validators=[past_date_validator])
-            to = serializers.DateTimeField(validators=[past_date_validator])
+            vars()['from'] = ABDMDateTimeField(validators=[past_date_validator])
+            to = ABDMDateTimeField(validators=[past_date_validator])
 
         dateRange = DateRangeSerializer()
-        dataEraseAt = serializers.DateTimeField(validators=[future_date_validator])
+        dataEraseAt = ABDMDateTimeField(validators=[future_date_validator])
 
     purpose = PurposeSerializer()
     patient = GatewayIdSerializer()
@@ -86,7 +87,7 @@ class GatewayConsentRequestOnFetchSerializer(GatewayCallbackResponseBaseSerializ
         class ConsentDetailSerializer(serializers.Serializer):
             schemaVersion = serializers.CharField(required=False)
             consentId = serializers.UUIDField()
-            createdAt = serializers.DateTimeField()
+            createdAt = ABDMDateTimeField()
             patient = GatewayIdSerializer()
             careContexts = serializers.ListField(child=GatewayCareContextSerializer(), min_length=1)
             purpose = GatewayPurposeSerializer()

--- a/abdm_integrator/hiu/views/consents.py
+++ b/abdm_integrator/hiu/views/consents.py
@@ -29,15 +29,19 @@ from abdm_integrator.utils import ABDMRequestHelper, APIResultsSetPagination
 
 
 class GenerateConsent(HIUBaseView):
+
     def post(self, request, format=None):
         serializer = GenerateConsentSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        consent_data = serializer.data
-        self.check_if_health_id_exists(consent_data['patient']['id'])
-        gateway_request_id = self.gateway_consent_request_init(consent_data)
-        consent_request = self.save_consent_request(gateway_request_id, consent_data, request.user)
-        return Response(status=HTTP_201_CREATED,
-                        data=ConsentRequestSerializer(consent_request).data)
+        self.check_if_health_id_exists(serializer.data['patient']['id'])
+        gateway_request_id = self.gateway_consent_request_init(serializer.data)
+        consent_request = self.save_consent_request(
+            gateway_request_id,
+            serializer.validated_data,
+            serializer.data,
+            request.user
+        )
+        return Response(status=HTTP_201_CREATED, data=ConsentRequestSerializer(consent_request).data)
 
     def check_if_health_id_exists(self, health_id):
         payload = {'healthId': health_id}
@@ -55,9 +59,9 @@ class GenerateConsent(HIUBaseView):
         ABDMRequestHelper().gateway_post(HIUGatewayAPIPath.CONSENT_REQUEST_INIT, payload)
         return payload['requestId']
 
-    def save_consent_request(self, gateway_request_id, consent_data, user):
-        consent_request = ConsentRequest(user=user, gateway_request_id=gateway_request_id, details=consent_data)
-        consent_request.update_user_amendable_details(consent_data['permission'], consent_data['hiTypes'])
+    def save_consent_request(self, gateway_request_id, validated_data, serialized_data, user):
+        consent_request = ConsentRequest(user=user, gateway_request_id=gateway_request_id, details=serialized_data)
+        consent_request.update_user_amendable_details(validated_data['permission'], validated_data['hiTypes'])
         return ConsentRequest.objects.get(gateway_request_id=gateway_request_id)
 
 
@@ -164,8 +168,9 @@ class GatewayConsentRequestNotifyProcessor:
 class GatewayConsentRequestOnFetch(HIUGatewayBaseView):
 
     def post(self, request, format=None):
-        GatewayConsentRequestOnFetchSerializer(data=request.data).is_valid(raise_exception=True)
-        self.process_request(request.data)
+        serializer = GatewayConsentRequestOnFetchSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.process_request(serializer.data)
         return Response(status=HTTP_202_ACCEPTED)
 
     @transaction.atomic

--- a/abdm_integrator/hiu/views/health_information.py
+++ b/abdm_integrator/hiu/views/health_information.py
@@ -25,7 +25,13 @@ from abdm_integrator.hiu.serializers.health_information import (
 from abdm_integrator.hiu.tasks import process_hiu_health_information_receiver
 from abdm_integrator.hiu.views.base import HIUBaseView, HIUGatewayBaseView
 from abdm_integrator.settings import app_settings
-from abdm_integrator.utils import ABDMCache, ABDMRequestHelper, abdm_iso_to_datetime, poll_and_pop_data_from_cache
+from abdm_integrator.utils import (
+    ABDMCache,
+    ABDMRequestHelper,
+    abdm_iso_to_datetime,
+    datetime_to_abdm_iso,
+    poll_and_pop_data_from_cache,
+)
 
 logger = logging.getLogger('abdm_integrator')
 
@@ -308,7 +314,7 @@ class ReceiveHealthInformationProcessor:
         payload['notification'] = {
             'consent_id': str(artefact.artefact_id),
             'transaction_id': self.request_data['transactionId'],
-            'doneAt': datetime.utcnow().isoformat(),
+            'doneAt': datetime_to_abdm_iso(datetime.utcnow()),
             'notifier': {
                 'type': RequesterType.HIU,
                 'id': self.get_hiu_id_from_consent()

--- a/abdm_integrator/serializers.py
+++ b/abdm_integrator/serializers.py
@@ -37,8 +37,8 @@ class GatewayRequesterSerializer(serializers.Serializer):
 
 
 class DateRangeSerializer(serializers.Serializer):
-    vars()['from'] = serializers.DateTimeField()
-    to = serializers.DateTimeField()
+    vars()['from'] = ABDMDateTimeField()
+    to = ABDMDateTimeField()
 
 
 class GatewayPermissionSerializer(serializers.Serializer):
@@ -50,7 +50,7 @@ class GatewayPermissionSerializer(serializers.Serializer):
 
     accessMode = serializers.ChoiceField(choices=DataAccessMode.CHOICES)
     dateRange = DateRangeSerializer()
-    dataEraseAt = serializers.DateTimeField()
+    dataEraseAt = ABDMDateTimeField()
     frequency = FrequencySerializer()
 
 
@@ -77,7 +77,7 @@ class GatewayPurposeSerializer(serializers.Serializer):
 class GatewayKeyMaterialSerializer(serializers.Serializer):
 
     class DHPublicKeySerializer(serializers.Serializer):
-        expiry = serializers.DateTimeField()
+        expiry = ABDMDateTimeField()
         parameters = serializers.CharField()
         keyValue = serializers.CharField()
 

--- a/abdm_integrator/serializers.py
+++ b/abdm_integrator/serializers.py
@@ -1,6 +1,19 @@
 from rest_framework import serializers
 
 from abdm_integrator.const import ConsentPurpose, DataAccessMode, TimeUnit
+from abdm_integrator.utils import datetime_to_abdm_iso
+
+
+class ABDMDateTimeField(serializers.DateTimeField):
+    """Serializer Date time field with serialized value as iso 8601 in milliseconds and Z appended at the end"""
+
+    def to_representation(self, value):
+        if not value:
+            return None
+        if isinstance(value, str):
+            return value
+        value = self.enforce_timezone(value)
+        return datetime_to_abdm_iso(value)
 
 
 class GatewayIdSerializer(serializers.Serializer):

--- a/abdm_integrator/serializers.py
+++ b/abdm_integrator/serializers.py
@@ -20,6 +20,11 @@ class GatewayIdSerializer(serializers.Serializer):
     id = serializers.CharField()
 
 
+class GatewayIdNameSerializer(serializers.Serializer):
+    id = serializers.CharField()
+    name = serializers.CharField(required=False, allow_null=True)
+
+
 class GatewayCareContextSerializer(serializers.Serializer):
     patientReference = serializers.CharField()
     careContextReference = serializers.CharField()

--- a/abdm_integrator/tests/test_utils.py
+++ b/abdm_integrator/tests/test_utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 import requests
@@ -7,6 +8,8 @@ from abdm_integrator.exceptions import ABDMGatewayError
 from abdm_integrator.utils import (
     ABDMCache,
     ABDMRequestHelper,
+    abdm_iso_to_datetime,
+    datetime_to_abdm_iso,
     poll_and_pop_data_from_cache,
     removes_prefix_for_abdm_mobile,
 )
@@ -97,3 +100,17 @@ class TestUtils(SimpleTestCase):
         self.assertEqual(removes_prefix_for_abdm_mobile('+91-9988776655'), '9988776655')
         self.assertEqual(removes_prefix_for_abdm_mobile('+919988776655'), '9988776655')
         self.assertEqual(removes_prefix_for_abdm_mobile('9988776655'), '9988776655')
+
+    def test_datetime_to_abdm_iso(self):
+        date1 = datetime(year=2023, month=1, day=1, hour=1, minute=1, second=1, microsecond=123456)
+        date2 = datetime(year=2023, month=1, day=1, hour=1, minute=1, second=1, microsecond=123)
+        date3 = datetime(year=2023, month=1, day=1, hour=1, minute=1, second=1)
+        self.assertEqual(datetime_to_abdm_iso(date1), '2023-01-01T01:01:01.123Z')
+        self.assertEqual(datetime_to_abdm_iso(date2), '2023-01-01T01:01:01.000Z')
+        self.assertEqual(datetime_to_abdm_iso(date3), '2023-01-01T01:01:01.000Z')
+
+    def test_abdm_iso_to_datetime(self):
+        expected_date = datetime(year=2023, month=1, day=1, hour=1, minute=1, second=1, microsecond=123000)
+        self.assertEqual(abdm_iso_to_datetime('2023-01-01T01:01:01.123Z'), expected_date)
+        self.assertEqual(abdm_iso_to_datetime('2023-01-01T01:01:01.123000Z'), expected_date)
+        self.assertEqual(abdm_iso_to_datetime('2023-01-01T01:01:01.123000'), expected_date)

--- a/abdm_integrator/user_auth/serializers.py
+++ b/abdm_integrator/user_auth/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from abdm_integrator.const import AuthenticationMode, AuthFetchModesPurpose, Gender, IdentifierType, RequesterType
-from abdm_integrator.serializers import GatewayCallbackResponseBaseSerializer
+from abdm_integrator.serializers import ABDMDateTimeField, GatewayCallbackResponseBaseSerializer
 
 
 class AuthFetchModesSerializer(serializers.Serializer):
@@ -26,7 +26,7 @@ class GatewayAuthOnFetchModesSerializer(GatewayCallbackResponseBaseSerializer):
 
 class AuthRequesterSerializer(serializers.Serializer):
     type = serializers.ChoiceField(choices=RequesterType.CHOICES)
-    id = serializers.CharField()
+    id = serializers.CharField(required=False)
 
 
 class AuthInitSerializer(serializers.Serializer):
@@ -39,6 +39,7 @@ class AuthInitSerializer(serializers.Serializer):
     def validate_authMode(self, data):
         if data == AuthenticationMode.DIRECT:
             raise serializers.ValidationError(f"'{AuthenticationMode.DIRECT}' Auth mode is not supported!")
+        return data
 
 
 class GatewayAuthOnInitSerializer(GatewayCallbackResponseBaseSerializer):
@@ -85,7 +86,7 @@ class GatewayAuthOnConfirmSerializer(GatewayCallbackResponseBaseSerializer):
         class TokenValiditySerializer(serializers.Serializer):
             purpose = serializers.ChoiceField(choices=AuthFetchModesPurpose.CHOICES)
             requester = AuthRequesterSerializer()
-            expiry = serializers.DateTimeField()
+            expiry = ABDMDateTimeField()
             limit = serializers.IntegerField()
 
         class PatientDemographicSerializer(serializers.Serializer):

--- a/abdm_integrator/utils.py
+++ b/abdm_integrator/utils.py
@@ -141,6 +141,10 @@ def abdm_iso_to_datetime(value):
     return parse_datetime(value).replace(tzinfo=None)
 
 
+def datetime_to_abdm_iso(value):
+    return value.isoformat(timespec='milliseconds') + 'Z'
+
+
 def json_from_file(file_path):
     with open(file_path) as file:
         return json.load(file)

--- a/abdm_integrator/utils.py
+++ b/abdm_integrator/utils.py
@@ -109,7 +109,10 @@ class ABDMRequestHelper:
 
     @staticmethod
     def common_request_data():
-        return {'requestId': str(uuid.uuid4()), 'timestamp': datetime.utcnow().isoformat()}
+        return {
+            'requestId': str(uuid.uuid4()),
+            'timestamp': datetime_to_abdm_iso(datetime.utcnow()),
+        }
 
     @staticmethod
     def _handle_abha_http_error(api_path, http_error, request_type='GET'):


### PR DESCRIPTION
**Context**
For datetime format for outgoing calls, we use serializers (at most places) and use isoformat at other places. The serializers utilise 
drf setting [DATE_FORMAT](https://www.django-rest-framework.org/api-guide/settings/#date_format) for the conversion which is set at project level.
Python isoformat uses microseconds by default and in HQ it is also set to use microseconds currently.

It has been observed a couple of times that ABDM APIs gave an error for the datetime format that it was incorrect and was expecting milliseconds. The error went away on its own after some time. 
And Irony is they themselves use microseconds for the callback APIs.

**Change Made**
In order to be safe, this PR makes sure that all outbound calls to ABDM uses the format of milliseconds instead of microseconds with `Z` appended at the end.
